### PR TITLE
Add more depth grid search control

### DIFF
--- a/gfast.props.SA
+++ b/gfast.props.SA
@@ -103,6 +103,10 @@ deltaLatitude = 0.1
 deltaLongitude = 0.1
 nlats_in_pgd_gridSearch = 1
 nlons_in_pgd_gridSearch = 1
+# depth grid search will start at start_depth, increase by deltaDepth until
+# it has ndepths_in_pgd_gridSearch
+start_depth = 1
+deltaDepth = 2
 ndepths_in_pgd_gridSearch = 10
 # These are the defaults:
 pgd_window_vel = 3.0
@@ -124,6 +128,10 @@ deltaLatitude = 0.1
 deltaLongitude = 0.1
 nlats_in_cmt_gridSearch = 1
 nlons_in_cmt_gridSearch = 1
+# depth grid search will start at start_depth, increase by deltaDepth until
+# it has ndepths_in_cmt_gridSearch
+start_depth = 1
+deltaDepth = 2
 ndepths_in_cmt_gridSearch = 10
 # These are the defaults:
 cmt_window_vel = 2.0

--- a/include/gfast_struct.h
+++ b/include/gfast_struct.h
@@ -29,6 +29,8 @@ struct GFAST_pgd_props_struct
 			  grid search. */
   double dLon;          /*!< Longitude perturbation (degrees) in epicentral
 			  grid search. */
+  double dDep;          /*!< Depth perturbation (km) in hypocentral grid search. */
+  double start_depth;   /*!< Initial depth (km) in hypocentral grid search. */
   int min_sites;        /*!< Minimum number of sites required to
 			  proceed with PGD inversion. */
   int verbose;          /*!< Controls verbosity - errors will always
@@ -83,6 +85,8 @@ struct GFAST_cmt_props_struct
 			  grid search. */
   double dLon;          /*!< Longitude perturbation (degrees) in epicentral
 			  grid search. */
+  double dDep;          /*!< Depth perturbation (km) in hypocentral grid search. */
+  double start_depth;   /*!< Initial depth (km) in hypocentral grid search. */
   int min_sites;        /*!< Minimum number of sites required to
 			  proceed with CMT inversion. */
   int verbose;          /*!< Controls verbosity - errors will always

--- a/src/core/cmt/initialize.c
+++ b/src/core/cmt/initialize.c
@@ -114,10 +114,10 @@ int core_cmt_initialize(struct GFAST_cmt_props_struct props,
     cmt->Ninp      = memory_calloc64f(cmt->nsites);
     cmt->Uinp      = memory_calloc64f(cmt->nsites);
     cmt->lsiteUsed = memory_calloc8l(cmt->nsites);
-    /* TODO fix me */
+    
     for (i = 0; i < cmt->ndeps; i++)
     {
-        cmt->srcDepths[i] = (double) (i + 1);
+        cmt->srcDepths[i] = props.start_depth + ((double) i * props.dDep);
     }
     // srcLats is a relative array centered at 0, to be added to the input latitude
     // The first latitude will be -dLat*(nlats - 1)/2

--- a/src/core/cmt/readIni.c
+++ b/src/core/cmt/readIni.c
@@ -99,6 +99,22 @@ int core_cmt_readIni(const char *propfilename,
         LOG_WARNMSG("%s", "Adding 1 point to CMT lon gridsearch");
         cmt_props->ngridSearch_lons = cmt_props->ngridSearch_lons + 1;
     }
+    setVarName(group, "deltaDepth\0", var);
+    cmt_props->dDep
+         = iniparser_getdouble(ini, var, 1);
+    if (cmt_props->dDep < 0.0)
+    {
+        LOG_ERRMSG("Error CMT depth search delta %f must be positive", cmt_props->dDep);
+        goto ERROR;
+    }
+    setVarName(group, "start_depth\0", var);
+    cmt_props->start_depth
+         = iniparser_getdouble(ini, var, 0);
+    if (cmt_props->start_depth < 0.0)
+    {
+        LOG_ERRMSG("Error CMT start depth %f must be >= 0", cmt_props->start_depth);
+        goto ERROR;
+    }
     setVarName(group, "ndepths_in_cmt_gridSearch\0", var);
     cmt_props->ngridSearch_deps = iniparser_getint(ini, var, 100);
     if (cmt_props->ngridSearch_deps < 1)

--- a/src/core/properties/print.c
+++ b/src/core/properties/print.c
@@ -169,6 +169,10 @@ void core_properties_print(struct GFAST_props_struct props)
                 lspace, props.pgd_props.ngridSearch_lons);
         LOG_DEBUGMSG("%s GFAST Number of PGD grid search depths is %d",
                 lspace, props.pgd_props.ngridSearch_deps);
+        LOG_DEBUGMSG("%s GFAST PGD grid search starting depth is %f",
+                lspace, props.pgd_props.start_depth);
+        LOG_DEBUGMSG("%s GFAST PGD grid search depth delta is %f",
+                lspace, props.pgd_props.dDep);
         LOG_DEBUGMSG("%s GFAST PGD data selection velocity is %f (km/s)",
                 lspace, props.pgd_props.window_vel);
         LOG_DEBUGMSG("%s GFAST Number of sites required to compute PGD is %d",
@@ -300,6 +304,10 @@ void core_properties_print(struct GFAST_props_struct props)
                 lspace, props.cmt_props.ngridSearch_lons);
         LOG_DEBUGMSG("%s GFAST Number of depths in CMT grid search  %d",
                 lspace, props.cmt_props.ngridSearch_deps);
+        LOG_DEBUGMSG("%s GFAST CMT grid search starting depth is %f",
+                lspace, props.cmt_props.start_depth);
+        LOG_DEBUGMSG("%s GFAST CMT grid search depth delta is %f",
+                lspace, props.cmt_props.dDep);
         LOG_DEBUGMSG("%s GFAST CMT data selection velocity is %f (km/s)",
                 lspace, props.cmt_props.window_vel);
         LOG_DEBUGMSG("%s GFAST CMT data averaging window length %f (s)",

--- a/src/core/scaling/pgd_initialize.c
+++ b/src/core/scaling/pgd_initialize.c
@@ -112,10 +112,10 @@ int core_scaling_pgd_initialize(struct GFAST_pgd_props_struct pgd_props,
     pgd->srdist     = memory_calloc64f(pgd->nsites * nloc);
     pgd->UPinp      = memory_calloc64f(pgd->nsites);
     pgd->lsiteUsed  = memory_calloc8l(pgd->nsites);
-    // TODO: fix me and make customizable!
+    
     for (i = 0; i < pgd->ndeps; i++)
     {
-        pgd->srcDepths[i] = (double) i + 1;
+        pgd->srcDepths[i] = pgd_props.start_depth + ((double) i * pgd_props.dDep);
     }
     // srcLats is a relative array centered at 0, to be added to the input latitude
     // The first latitude will be -dLat*(nlats - 1)/2

--- a/src/core/scaling/pgd_readIni.c
+++ b/src/core/scaling/pgd_readIni.c
@@ -119,6 +119,22 @@ int core_scaling_pgd_readIni(const char *propfilename,
         pgd_props->ngridSearch_lons
            = pgd_props->ngridSearch_lons + 1;
     }
+    setVarName(group, "deltaDepth\0", var);
+    pgd_props->dDep
+         = iniparser_getdouble(ini, var, 1);
+    if (pgd_props->dDep < 0.0)
+    {
+        LOG_ERRMSG("Error PGD depth search delta %f must be positive", pgd_props->dDep);
+        goto ERROR;
+    }
+    setVarName(group, "start_depth\0", var);
+    pgd_props->start_depth
+         = iniparser_getdouble(ini, var, 0);
+    if (pgd_props->start_depth < 0.0)
+    {
+        LOG_ERRMSG("Error PGD start depth %f must be >= 0", pgd_props->start_depth);
+        goto ERROR;
+    }
     setVarName(group, "ndepths_in_pgd_gridSearch\0", var);
     pgd_props->ngridSearch_deps
          = iniparser_getint(ini, var, 100);

--- a/src/tests/CoreDataUT.cc
+++ b/src/tests/CoreDataUT.cc
@@ -113,11 +113,17 @@ TEST(CoreData, testReadSiteMaskFile) {
     GFAST_core_data_finalize(&gps_data);
 }
 
-TEST(CoreData, testInitialize) {
+TEST(CoreData, testInitializeDefault) {
     char propfilename[1024];
     int ierr, i;
     struct GFAST_props_struct props;
     struct GFAST_data_struct gps_data;
+    struct GFAST_pgdResults_struct pgd;
+    struct GFAST_peakDisplacementData_struct pgd_data;
+    struct GFAST_cmtResults_struct cmt;
+    struct GFAST_offsetData_struct cmt_data, ff_data;
+    struct GFAST_ffResults_struct ff;
+
     const enum opmode_type opmode = REAL_TIME_EEW;
 
     // initialize
@@ -127,6 +133,12 @@ TEST(CoreData, testInitialize) {
     ierr = 0;
     memset(&props, 0, sizeof(struct GFAST_props_struct));
     memset(&gps_data, 0, sizeof(struct GFAST_data_struct));
+    memset(&pgd, 0, sizeof(struct GFAST_pgdResults_struct));
+    memset(&cmt, 0, sizeof(struct GFAST_cmtResults_struct));
+    memset(&ff, 0, sizeof(struct GFAST_ffResults_struct));
+    memset(&pgd_data, 0, sizeof( struct GFAST_peakDisplacementData_struct));
+    memset(&cmt_data, 0, sizeof(struct GFAST_offsetData_struct));
+    memset(&ff_data, 0, sizeof(struct GFAST_offsetData_struct));
 
     // First read the properties
     ierr = GFAST_core_properties_initialize(propfilename, opmode, &props);
@@ -143,6 +155,90 @@ TEST(CoreData, testInitialize) {
         EXPECT_NE(gps_data.data[i].ebuff, nullptr);
         EXPECT_NE(gps_data.data[i].tbuff, nullptr);
     }
+
+    // Initialize PGD
+    ierr = core_scaling_pgd_initialize(props.pgd_props, gps_data, &pgd, &pgd_data);
+    EXPECT_EQ(0, ierr);
+    printf("PGD depths:\n");
+    for (i = 0; i < pgd.ndeps; i++) {
+        printf("%02d: %f\n", i, pgd.srcDepths[i]);
+    }
+    // Initialize CMT
+    ierr = core_cmt_initialize(props.cmt_props, gps_data, &cmt, &cmt_data);
+    EXPECT_EQ(0, ierr);
+    printf("CMT depths:\n");
+    for (i = 0; i < cmt.ndeps; i++) {
+        printf("%02d: %f\n", i, cmt.srcDepths[i]);
+    }
+    // Initialize finite fault
+    ierr = core_ff_initialize(props.ff_props, gps_data, &ff, &ff_data);
+    EXPECT_EQ(0, ierr);
+
+    // finalize
+    GFAST_core_data_finalize(&gps_data);
+    GFAST_core_properties_finalize(&props);
+}
+
+TEST(CoreData, testInitializeSpecific) {
+    char propfilename[1024];
+    int ierr, i;
+    struct GFAST_props_struct props;
+    struct GFAST_data_struct gps_data;
+    struct GFAST_pgdResults_struct pgd;
+    struct GFAST_peakDisplacementData_struct pgd_data;
+    struct GFAST_cmtResults_struct cmt;
+    struct GFAST_offsetData_struct cmt_data, ff_data;
+    struct GFAST_ffResults_struct ff;
+
+    const enum opmode_type opmode = REAL_TIME_EEW;
+
+    // initialize
+    strncpy(propfilename,
+            "data/gfast.props.depthsearch",
+            1024-1);
+    ierr = 0;
+    memset(&props, 0, sizeof(struct GFAST_props_struct));
+    memset(&gps_data, 0, sizeof(struct GFAST_data_struct));
+    memset(&pgd, 0, sizeof(struct GFAST_pgdResults_struct));
+    memset(&cmt, 0, sizeof(struct GFAST_cmtResults_struct));
+    memset(&ff, 0, sizeof(struct GFAST_ffResults_struct));
+    memset(&pgd_data, 0, sizeof( struct GFAST_peakDisplacementData_struct));
+    memset(&cmt_data, 0, sizeof(struct GFAST_offsetData_struct));
+    memset(&ff_data, 0, sizeof(struct GFAST_offsetData_struct));
+
+    // First read the properties
+    ierr = GFAST_core_properties_initialize(propfilename, opmode, &props);
+    EXPECT_EQ(0, ierr);
+
+    // Now actually test the function in question
+    ierr = core_data_initialize(props, &gps_data);
+    EXPECT_EQ(0, ierr);
+
+    for ( i = 0; i < gps_data.stream_length; i++ ) {
+        EXPECT_GT(gps_data.data[i].maxpts, 0);
+        EXPECT_NE(gps_data.data[i].ubuff, nullptr);
+        EXPECT_NE(gps_data.data[i].nbuff, nullptr);
+        EXPECT_NE(gps_data.data[i].ebuff, nullptr);
+        EXPECT_NE(gps_data.data[i].tbuff, nullptr);
+    }
+
+    // Initialize PGD
+    ierr = core_scaling_pgd_initialize(props.pgd_props, gps_data, &pgd, &pgd_data);
+    EXPECT_EQ(0, ierr);
+    printf("PGD depths:\n");
+    for (i = 0; i < pgd.ndeps; i++) {
+        printf("%02d: %f\n", i, pgd.srcDepths[i]);
+    }
+    // Initialize CMT
+    ierr = core_cmt_initialize(props.cmt_props, gps_data, &cmt, &cmt_data);
+    EXPECT_EQ(0, ierr);
+    printf("CMT depths:\n");
+    for (i = 0; i < cmt.ndeps; i++) {
+        printf("%02d: %f\n", i, cmt.srcDepths[i]);
+    }
+    // Initialize finite fault
+    ierr = core_ff_initialize(props.ff_props, gps_data, &ff, &ff_data);
+    EXPECT_EQ(0, ierr);
 
     // finalize
     GFAST_core_data_finalize(&gps_data);

--- a/src/tests/CoreScalingUT.cc
+++ b/src/tests/CoreScalingUT.cc
@@ -198,3 +198,45 @@ TEST(CoreScaling, testReadRawSigmaThresholdLookupFileNoExist) {
     EXPECT_DOUBLE_EQ(-1, pgd_props.n_raw_sigma_threshold);
     EXPECT_DOUBLE_EQ(-1, pgd_props.e_raw_sigma_threshold);
 }
+
+/**
+ * Test the core_scaling_pgd_readIni function that reads in properties
+ */
+TEST(CoreScaling, testReadPropertiesDepth) {
+    const char *propertiesFile;
+    int ierr;
+    struct GFAST_pgd_props_struct pgd_props;
+
+    propertiesFile = "data/gfast.props.depthsearch\0";
+    memset(&pgd_props, 0, sizeof(struct GFAST_pgd_props_struct));
+
+    ierr = core_scaling_pgd_readIni(propertiesFile, "PGD\0",
+				  1, -12345,
+				  &pgd_props);
+
+    EXPECT_EQ(0, ierr);
+    EXPECT_EQ(1, pgd_props.start_depth);
+    EXPECT_EQ(2, pgd_props.dDep);
+    
+}
+
+/**
+ * Test the core_scaling_pgd_readIni function that reads in properties
+ */
+TEST(CoreScaling, testReadPropertiesDefault) {
+    const char *propertiesFile;
+    int ierr;
+    struct GFAST_pgd_props_struct pgd_props;
+
+    propertiesFile = "data/gfast.props\0";
+    memset(&pgd_props, 0, sizeof(struct GFAST_pgd_props_struct));
+
+    ierr = core_scaling_pgd_readIni(propertiesFile, "PGD\0",
+				  1, -12345,
+				  &pgd_props);
+
+    EXPECT_EQ(0, ierr);
+    EXPECT_EQ(0, pgd_props.start_depth);
+    EXPECT_EQ(1, pgd_props.dDep);
+    
+}

--- a/src/tests/EewUtilsUT.cc
+++ b/src/tests/EewUtilsUT.cc
@@ -90,11 +90,25 @@ TEST(Eewutils, testDrivePGD) {
     pgd.UP = ISCL_memory_calloc__double(pgd.ndeps*pgd.nsites);
     pgd.UPinp = ISCL_memory_calloc__double(pgd.nsites);
     pgd.srcDepths = ISCL_memory_calloc__double(pgd.ndeps);
+    pgd.srcLats = ISCL_memory_calloc__double(pgd.nlats);
+    pgd.srcLons = ISCL_memory_calloc__double(pgd.nlons);
     pgd.srdist = ISCL_memory_calloc__double(pgd.ndeps*pgd.nsites);
     pgd.lsiteUsed = ISCL_memory_calloc__bool(pgd.nsites);
     for (i=0; i<pgd.ndeps; i++)
     {
         pgd.srcDepths[i] = pgd_ref.srcDepths[i];
+    }
+    // srcLats is a relative array centered at 0, to be added to the input latitude
+    // The first latitude will be -dLat*(nlats - 1)/2
+    for (i = 0; i < pgd.nlats; i++)
+    {
+        pgd.srcLats[i] = pgd_props.dLat * (i - (pgd.nlats - 1) / 2);
+    }
+    // srcLons is a relative array centered at 0, to be added to the input longitude
+    // The first longitude will be -dLon*(nlons - 1)/2
+    for (i = 0; i < pgd.nlons; i++)
+    {
+        pgd.srcLons[i] = pgd_props.dLon * (i - (pgd.nlons - 1) / 2);
     }
     ierr = eewUtils_drivePGD(pgd_props,
                              SA_lat, SA_lon, SA_dep, age_of_event,
@@ -154,6 +168,8 @@ TEST(Eewutils, testDriveCMT) {
     cmt.rak2 = memory_calloc64f(cmt.ndeps);
     cmt.Mw = memory_calloc64f(cmt.ndeps);
     cmt.srcDepths = memory_calloc64f(cmt.ndeps);
+    cmt.srcLats = memory_calloc64f(cmt.nlats);
+    cmt.srcLons = memory_calloc64f(cmt.nlons);
     cmt.EN = memory_calloc64f(cmt.ndeps*cmt_data.nsites);
     cmt.NN = memory_calloc64f(cmt.ndeps*cmt_data.nsites);
     cmt.UN = memory_calloc64f(cmt.ndeps*cmt_data.nsites);
@@ -164,6 +180,18 @@ TEST(Eewutils, testDriveCMT) {
     for (i=0; i<cmt.ndeps; i++)
     {
         cmt.srcDepths[i] = cmt_ref.srcDepths[i];
+    }
+    // srcLats is a relative array centered at 0, to be added to the input latitude
+    // The first latitude will be -dLat*(nlats - 1)/2
+    for (i = 0; i < cmt.nlats; i++)
+    {
+        cmt.srcLats[i] = cmt_props.dLat * (i - (cmt.nlats - 1) / 2);
+    }
+    // srcLons is a relative array centered at 0, to be added to the input longitude
+    // The first longitude will be -dLon*(nlons - 1)/2
+    for (i = 0; i < cmt.nlons; i++)
+    {
+        cmt.srcLons[i] = cmt_props.dLon * (i - (cmt.nlons - 1) / 2);
     }
     ierr = eewUtils_driveCMT(cmt_props,
                              SA_lat, SA_lon, SA_dep,

--- a/src/tests/data/gfast.props.depthsearch
+++ b/src/tests/data/gfast.props.depthsearch
@@ -1,0 +1,207 @@
+################################################################################
+#                             Global G-FAST properties                         #
+################################################################################
+[general]
+# File for log output
+logFileName=data/gfast.log
+# File with station names
+metaDataFile=data/merged_chanfile_coord.dat
+#metaDataNetworks=PW
+#SA_events_dir=xxxxx
+SA_output_dir=data
+#output_interval_mins=1,2,3,4,5,10
+siteMaskFile=data/site_mask_file.dat
+# File with station names and sampling periods
+#dtfile=GFAST_streams_dt.txt
+# ElarmS message file
+#eewsfile=ElarmS_messages.txt
+# GFAST results file
+eewgfile=GFAST_output.txt
+# File of all the site locations. The format used is currently from 
+# the SOPAC SECTOR web service.
+siteposfile=site_pos.csv 
+# Buffer length (s)
+bufflen=320.
+processing_time=302.
+# GFAST operation mode
+#  1 -> GFAST is running in `real time' and being data through Earthworm 
+#  2 -> GFAST is running historical playbacks through Earthworm
+#  3 -> GFAST is running offline and is obtaining data purely from files
+opmode = 1
+# minimum time for main loop (defaults to 1 second)
+#waitTime=1.0
+# The synthetic mode driver file
+#syndriver=nisqually_driver.txt
+# The synthetic mode output file
+#synoutput=nisqually_output.txt
+# If working in specific area where the fault may straddle a UTM zone large
+# distortions can arise.  In this case it may be beneficial to set the UTM
+# zone.  Otherwise, if utm_zone is set to -12345 or not specified the UTM
+# zone will be estimated from the event hpyocenter provided in the ElarmS
+# message 
+utm_zone = 10 
+# Mechanism for initializing sampling period
+#  1 -> Sets GPS sampling period to default (dt_default)
+#  2 -> Obtains the sampling period from the dtfile 
+#  3 -> Obtains the sampling period from Earthworm
+dt_init = 3
+# Default GPS sampling period (s)
+dt_default = 1.0
+# Location initialization strategy
+#  1 -> Initialize locations from SOPAC SECTOR web service (siteposfile)
+#  2 -> Initialize from trace buffer (if running in real-time this will
+#       happen automatically)
+loc_init = 1
+# Controls verbosity:
+# 0 -> Try to output nothing
+# 1 -> Output errors only
+# 2 -> Output errors and generic information (default)
+# 3 -> Output errors, generic information, and debug information
+verbose=3
+
+synthetic_runtime = 0.0 
+processing_time = 300.0
+default_event_depth = 8.0
+
+h5ArchiveDirectory = data
+H5SummaryOnly = 1
+
+anssNetwork = UW
+anssDomain = anss.org
+
+################################################################################
+#                              Earthworm Properties                            #
+################################################################################
+[earthworm]
+
+gpsRingName = GPS_RING
+moduleName = geojson2ew
+
+################################################################################
+#                                  PGD Properties                              #
+################################################################################
+[PGD]
+# PGD source-receiver distance tolerance in km (cannot be negative)
+dist_tolerance = 0.6
+# If PGD source-receiver distance tolerance falls below dist_tol this is the
+# default PGD distance value given in km (must be positive)
+dist_default = 0.01
+#some search variables
+deltaLatitude = 0.1
+deltaLongitude = 0.1
+nlats_in_pgd_gridSearch = 1
+nlons_in_pgd_gridSearch = 1
+# depth grid search will start at start_depth, increase by deltaDepth until
+# it has ndepths_in_pgd_gridSearch
+start_depth = 1
+deltaDepth = 2
+ndepths_in_pgd_gridSearch = 10
+# These are the defaults:
+pgd_window_vel = 3.0
+pgd_min_sites = 4
+
+# Message throttling logic and related
+# Lookup table for non-density corrected value to generate magnitude 
+# uncertainty based on time and magnitude
+sigmaLookupFile = data/M99.txt
+# Lookup table for time-dependant PGD thresholds 
+# columns: time (s) | threshold (cm) | n stations
+pgdThresholdLookupFile = data/pgd_threshold_PW.txt
+# Positional uncertainty thresholds for including peak displacement observations
+# If not specified, allow any or NAN uncertainties
+rawSigmaThresholdLookupFile = data/raw_sigma_threshold_PW.txt
+
+# If defined, don't send xml if pgd_sigma is greater than this value
+pgd_sigma_throttle = 0.5
+# Message throttling logic
+SA_mag_threshold = 6.0
+
+# Minimum and maximum thresholds for using pgd values in inversion, in cm
+minimum_pgd_cm = 0.0
+maximum_pgd_cm = 3500.0
+max_assoc_stations = 6
+
+# Change thresholds to decide when to send a message, assuming other throttles
+# pass. If any of these are met or exceeded, a new message would be sent. If 
+# none are exceeded, message would not be sent.
+# If not present, threshold will be ignored
+change_threshold_mag = 0.05
+change_threshold_mag_uncer = 0.05
+change_threshold_lat = 0.05
+change_threshold_lon = 0.05
+change_threshold_orig_time = 1
+change_threshold_num_stations = 1
+
+################################################################################
+#                            CMT/Finite Fault Properties                       #
+################################################################################
+[CMT]
+#some search variables
+deltaLatitude = 0.1
+deltaLongitude = 0.1
+nlats_in_cmt_gridSearch = 1
+nlons_in_cmt_gridSearch = 1
+# depth grid search will start at start_depth, increase by deltaDepth until
+# it has ndepths_in_cmt_gridSearch
+start_depth = 2
+deltaDepth = 3
+ndepths_in_cmt_gridSearch = 10
+# These are the defaults:
+cmt_window_vel = 2.0
+cmt_min_sites = 4
+# Error window average must be positive
+cmt_window_avg = 0.0
+# Error general CMT inversions not yet programmed
+ldeviatoric_cmt = 1
+
+################################################################################
+#                             FF/Finite Fault Properties                       #
+################################################################################
+[FF]
+ff_number_of_faultplanes = 2
+# Number of fault patches along strike
+ff_nstr = 10
+# Number of fault patches down dip
+ff_ndip = 5
+# Min number of sites (must be greater than CMT)
+ff_min_sites = 4
+# Error window velocity
+ff_window_vel = 3.0
+# error window average time
+ff_window_avg = 10.0
+ff_flen_pct = 10.0
+ff_fwid_pct = 10.0
+
+################################################################################
+#                               ActiveMQ Properties                            #
+################################################################################
+[ActiveMQ]
+# ActiveMQ host:port
+### amq_dm openwire 61616
+### amq_wp openwire 62616
+### amq_sa openwire 63616
+#URL for event trigger messages
+originURL=tcp://eew-uw-dev1:63616
+#originURL=tcp://eew-uw-int1:63616
+# ActiveMQ topic to read event trigger messages from
+originTopic=eew.agg.sa.data
+#URL to publish event messages and heartbeats on
+destinationURL=tcp://localhost:62616
+# ActiveMQ topic to publish events on.
+destinationTopic = eew.alg.gfast.data
+# ActiveMQ topic to publish heartbeats on
+hbTopic=eew.alg.gfast.hb
+# heartbeat interval
+hbInterval=5
+# ActiveMQ username to access ElarmS messages
+user=glarms
+# ActiveMQ password to access ElarmS messages
+password=abcdefg
+
+# connection settings
+msReconnect = 500
+maxAttempts = 5
+msWaitForMessage = 0
+
+maxMessages=5
+

--- a/src/tests/gfast_ut_utils.h
+++ b/src/tests/gfast_ut_utils.h
@@ -51,6 +51,8 @@ int read_pgd_results(const char *filenm,
            &pgd_props->utm_zone, &pgd_props->min_sites, 
            &pgd_props->dist_tol, &pgd_props->disp_def,
            &pgd_props->window_vel);
+    pgd_props->dLat = 1;
+    pgd_props->dLon = 1;
     // line 2
     memset(cline, 0, sizeof(cline));
     if (fgets(cline, sizeof(cline), infl) == NULL){goto ERROR;}
@@ -137,6 +139,8 @@ int read_cmt_results(const char *filenm,
            &cmt_props->utm_zone, &cmt_props->min_sites, 
            &ldevi, &cmt_props->window_vel,
            &cmt_props->window_avg);
+    cmt_props->dLat = 1;
+    cmt_props->dLon = 1;
     cmt_props->ldeviatoric = true;
     if (ldevi != 1){cmt_props->ldeviatoric = false;}
     // line 2


### PR DESCRIPTION
Add new parameters for PGD and CMT depth grid search: `start_depth`, `deltaDepth`. These will make a depth array with `ndepths_in_pgd_gridSearch` elements starting at `start_depth` and incrementing by `deltaDepth`. The PGD and CMT parameters are independent, so can be set differently or the same.

Addresses #37 